### PR TITLE
libcxxrt: Account for the LSB in CLR for Morello.

### DIFF
--- a/src/dwarf_eh.h
+++ b/src/dwarf_eh.h
@@ -437,6 +437,10 @@ static bool dwarf_eh_find_callsite(struct _Unwind_Context *context,
 	result->landing_pad = 0;
 	// The current instruction pointer offset within the region
 	uint64_t ip = (char*)_Unwind_GetIP(context) - (char*)_Unwind_GetRegionStart(context);
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(__aarch64__)
+	// Account for the LSB in the address returned by _Unwind_GetIP().
+	ip &= ~(uint64_t)1;
+#endif
 	unsigned char *callsite_table = static_cast<unsigned char*>(lsda->call_site_table);
 
 	while (callsite_table <= lsda->action_table)


### PR DESCRIPTION
_Unwind_GetIP() returns the CLR for each stack frame which includes
the LSB.  When subtracted from the region start, this can result in an
off by one error for the IP offset used to find the correct call site.
Specifically, if the exception is thrown by the last instruction in
the call site (a call to _cxa_throw), then the IP offset will be one
byte beyond the end of the call site and fail to match.